### PR TITLE
Update driver.vrdrivermanifest

### DIFF
--- a/driver_files/driver/example/driver.vrdrivermanifest
+++ b/driver_files/driver/example/driver.vrdrivermanifest
@@ -3,6 +3,5 @@
 	"name" : "example",
 	"directory" : "",
 	"resourceOnly" : false,
-	"prefersUpperDeviceIndices" :  true,
 	"hmd_presence" : ["*.*"]
 }


### PR DESCRIPTION
the prefersUpperDeviceIndices property will stop games/applications such as VRChat to receive trackers' position info.